### PR TITLE
Fix regression in relay code (#2)

### DIFF
--- a/inocybe_dhcp/dhcpio.py
+++ b/inocybe_dhcp/dhcpio.py
@@ -36,16 +36,23 @@ MAXPACKET = 1500
 FILTER = "udp and (dst port 68) or (dst port 67)"
 ETH_BROADCAST = '\xff\xff\xff\xff\xff\xff'
 
-def print_mac(data):
-    '''Print out an IP addr as numeric'''
-    mac0, mac1, mac2, mac3, mac4, mac5 = struct.unpack("BBBBBB", data)
-    return "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(
-        mac0, mac1, mac2, mac3, mac4, mac5)
+def format_mac(data):
+    '''Print out a MAC addr in standard text form'''
+    try:
+        mac0, mac1, mac2, mac3, mac4, mac5 = struct.unpack("BBBBBB", data)
+        return "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(
+            mac0, mac1, mac2, mac3, mac4, mac5)
+    except struct.error:
+        return "{}".format(data)
 
-def print_ip(data):
-    '''Print out an IP addr as numeric'''
-    ip0, ip1, ip2, ip3 = struct.unpack("BBBB", data)
-    return "{}.{}.{}.{}".format(ip0, ip1, ip2, ip3)
+def format_ip(data):
+    '''Print out an IP addr as a dotted quad'''
+    try:
+        ip0, ip1, ip2, ip3 = struct.unpack("BBBB", data)
+        return "{}.{}.{}.{}".format(ip0, ip1, ip2, ip3)
+    except struct.error:
+        return "{}".format(data)
+
 
 
 class Ifinfo(object):
@@ -70,6 +77,8 @@ class Ifinfo(object):
         # pylint: disable=unused-variable
         except (IndexError, KeyError) as ignore:
             self.ipaddr = None
+        if self.ipaddr == None and trusted is None:
+            raise ValueError("Relay mode requires a v4 address on interface")
         # pylint: disable=no-member
         self.mac = ni.ifaddresses(iface)[ni.AF_PACKET][0]['addr']
         self.rawio = os.fdopen(self.pcap.fileno(), "w+")
@@ -138,11 +147,11 @@ class Ifinfo(object):
         )
         if to_server:
             logging.debug("Raw socket to server on %s using %s/%s",
-                          self.iface, print_ip(ipaddr), print_mac(mac))
+                          self.iface, format_ip(ipaddr), format_mac(mac))
             self.trust_sock.send(str(eth))
         else:
             logging.debug("Raw socket to client on %s using %s/%s",
-                          self.iface, print_ip(ipaddr), print_mac(mac))
+                          self.iface, format_ip(ipaddr), format_mac(mac))
             self.rawio.write(str(eth))
             self.rawio.flush() # needed, otherwise python buffering messes it up
 

--- a/inocybe_dhcp/opx_dhcp.py
+++ b/inocybe_dhcp/opx_dhcp.py
@@ -26,8 +26,8 @@ import copy
 from argparse import ArgumentParser
 from inocybe_dhcp.dhcpio import DHCPIo
 from inocybe_dhcp.dhcpio import DHCPSERVER
-from inocybe_dhcp.dhcpio import print_ip
-from inocybe_dhcp.dhcpio import print_mac
+from inocybe_dhcp.dhcpio import format_ip
+from inocybe_dhcp.dhcpio import format_mac
 from inocybe_dhcp.rfc2131 import Message as DhcpMessage
 from inocybe_dhcp.options import BuiltIn as DhcpOptions
 from inocybe_dhcp.rfc3046 import RelayAgentInformation
@@ -44,12 +44,12 @@ DO_NOT_RELAY = 0
 UDP_RELAY = 1
 MITM_RELAY = 3
 
-MODULE = "dhcp-agent/if/interfaces/interface"
-IFROOT = "if/interfaces/interface"
-IFNAME = "if/interfaces/interface/name"
-DHCPPATH = "dhcp-agent/if/interfaces/interface"
-DHCPSERVER = "dhcp-agent/if/interfaces/interface/dhcp-server"
-DHCPTRUSTED = "dhcp-agent/if/interfaces/interface/trusted"
+MODULE_P = "dhcp-agent/if/interfaces/interface"
+IFROOT_P = "if/interfaces/interface"
+IFNAME_P = "if/interfaces/interface/name"
+DHCPPATH_P = "dhcp-agent/if/interfaces/interface"
+DHCPSERVER_P = "dhcp-agent/if/interfaces/interface/dhcp-server"
+DHCPTRUSTED_P = "dhcp-agent/if/interfaces/interface/trusted"
 
 
 # Initial assumption is that CPS will do a bound method as
@@ -87,8 +87,8 @@ class Agent(object):
         '''Extract if/interface/interfaces/name from filter'''
         try:
             return cps_utils.cps_attr_types_map.from_data(
-                IFNAME,
-                sfilter['data'][IFNAME])
+                IFNAME_P,
+                sfilter['data'][IFNAME_P])
         except KeyError:
             return None
 
@@ -100,10 +100,10 @@ class Agent(object):
             if (narrow_by is None) or (iface["name"] == narrow_by):
                 try:
                     obj = cps_object.CPSObject(
-                        module=MODULE, data={"dhcp-server":iface["dhcp-server"]})
+                        module=MODULE_P, data={"dhcp-server":iface["dhcp-server"]})
                 except KeyError:
                     obj = cps_object.CPSObject(
-                        module=MODULE, data={"trusted":iface["trusted"].encode('ascii')})
+                        module=MODULE_P, data={"trusted":iface["trusted"].encode('ascii')})
                 result.append(obj.get())
         return result
 
@@ -132,26 +132,29 @@ class Agent(object):
     @staticmethod
     def _add_change(iface, change):
         '''Add the incoming attribute to the iface'''
+        logging.debug("adding %s to %s ", "{}".format(change), "{}".format(iface))
         try:
             iface["dhcp-server"] = cps_utils.cps_attr_types_map.from_data(
-                DHCPSERVER,
-                change['data'][DHCPSERVER]
+                DHCPSERVER_P,
+                change['data'][DHCPSERVER_P]
             )
         except KeyError:
             iface["trusted"] = cps_utils.cps_attr_types_map.from_data(
-                DHCPTRUSTED,
-                change['data'][DHCPTRUSTED]
+                DHCPTRUSTED_P,
+                change['data'][DHCPTRUSTED_P]
             )
 
     def _create(self, change):
         '''Create entry in config'''
         narrow_by = self._narrow_by(change)
+        logging.debug("create for %s %s", "{}".format(narrow_by), "{}".format(change))
         if narrow_by is None:
             return False # we need an interface to be able to create
 
-        for iface in self._active_config:
-            if iface["name"] == narrow_by:
-                return False
+        if self._active_config is not None:
+            for iface in self._active_config:
+                if iface["name"] == narrow_by:
+                    return False
 
         new_config = copy.deepcopy(self._active_config)
 
@@ -162,7 +165,9 @@ class Agent(object):
         self._add_change(iface, change)
         new_config.append(iface)
         self._pending_config = new_config
+        logging.debug("pending config set to %s", "{}".format(self._pending_config))
         return True
+
     def _set(self, change):
         '''Set entry in config for a particular key'''
 
@@ -279,7 +284,7 @@ class Agent(object):
 
         # packet processing goes in here
         # insert giaddr option for relay mode
-        if ifinfo.dst is not None:
+        if ifinfo.dst is not None and ifinfo.ipaddr is not None:
             if parsed["op"] == BOOTREQUEST:
                 parsed['giaddr'] = ifinfo.ipaddr
                 relay = UDP_RELAY
@@ -287,8 +292,8 @@ class Agent(object):
             if parsed["op"] == BOOTREQUEST:
                 relay = MITM_RELAY
         logging.debug("Processing complete for %s from %s @ %s %s",
-                      parsed, print_ip(src_ip),
-                      print_mac(src_mac), relay)
+                      parsed, format_ip(src_ip),
+                      format_mac(src_mac), relay)
         return (parsed.pack(), ifinfo, src_ip, src_mac, relay)
 
 
@@ -329,12 +334,14 @@ def main():
 
     def get_cb(method, params):
         '''CPS get callback'''
+        logging.debug("Get CB invoked with %s", "{}".format(params))
         fobj = cps_object.CPSObject(obj=params['filter'])
         params['list'].extend(agent.get(fobj.get()))
         return True
 
     def trans_cb(method, params):
         '''CPS transaction callback'''
+        logging.debug("Trans CB invoked with %s", "{}".format(params))
         return agent.transaction(params['change'])
 
     agent = None
@@ -355,7 +362,7 @@ def main():
     # pylint: disable=no-member
     handle = cps.obj_init()
     # pylint: disable=no-member
-    cps.obj_register(handle, cps.key_from_name("target", DHCPPATH), dict_cb)
+    cps.obj_register(handle, cps.key_from_name("target", DHCPPATH_P), dict_cb)
 
     agent.main_loop()
 


### PR DESCRIPTION
* Fix regression in relay code

A regression to the relay code was introduced as a result
of adding some of the agent/mitm code. This commit fixes it.

Additionally, this commit adds debug and tracing to the cps code
paths.

* Add checks to prevent possible agent exits on no ip address

If an interface is unconfigured, the agent will exit when
trying to use it.

This commit adds some checks to prevent the most common cases.

* Address comments on style, naming and fix descriptions

Signed-off-by: Anton Ivanov <anton.ivanov@cambridgegreys.com>